### PR TITLE
Add Discussions Models and Entity

### DIFF
--- a/backend/entities/discussion_entity.py
+++ b/backend/entities/discussion_entity.py
@@ -1,0 +1,43 @@
+# discussions_entity.py
+
+from typing import List
+from sqlalchemy import Column, Integer, String, Table, ForeignKey
+from sqlalchemy.orm import relationship, Mapped, mapped_column
+from .base import Base
+from backend.models.discussion import DiscussionCreate, DiscussionUpdate, DiscussionResponse
+from backend.entities.user_entity import UserEntity
+
+association_table_discussion_participants = Table(
+    'association_discussion_participants', Base.metadata,
+    Column('discussion_id', ForeignKey('discussions.id'), primary_key=True),
+    Column('user_id', ForeignKey('users.id'), primary_key=True),
+    extend_existing=True
+)
+
+class DiscussionEntity(Base):
+    __tablename__ = 'discussions'
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True, autoincrement=True)
+    title: Mapped[str] = mapped_column(String, nullable=False)
+    description: Mapped[str] = mapped_column(String, nullable=False)
+    author_id: Mapped[int] = mapped_column(ForeignKey('users.id'), nullable=False)
+    author: Mapped[UserEntity] = relationship('UserEntity', back_populates='authored_discussions')
+    participants: Mapped[List[UserEntity]] = relationship('UserEntity', secondary=association_table_discussion_participants, back_populates='participating_discussions')
+
+    def to_discussion_response(self):
+        return DiscussionResponse(
+            id=self.id,
+            title=self.title,
+            description=self.description,
+            author=self.author.to_user_response(),
+            participants=[participant.to_user_response() for participant in self.participants]
+        )
+
+    @staticmethod
+    def from_model(discussion: DiscussionCreate, author: UserEntity, participants: List[UserEntity]):
+        return DiscussionEntity(
+            title=discussion.title,
+            description=discussion.description,
+            author=author,
+            participants=participants
+        )

--- a/backend/migrations/versions/1b1cbd10c22b_add_discussions_table.py
+++ b/backend/migrations/versions/1b1cbd10c22b_add_discussions_table.py
@@ -1,0 +1,38 @@
+"""Add discussions table
+
+Revision ID: 1b1cbd10c22b
+Revises: 660774b1923e
+Create Date: 2024-06-14 23:07:10.788396
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '1b1cbd10c22b'
+down_revision = '660774b1923e'
+branch_labels = None
+depends_on = None
+
+
+
+def upgrade():
+    op.create_table(
+        'discussions',
+        sa.Column('id', sa.Integer, primary_key=True, autoincrement=True),
+        sa.Column('title', sa.String, nullable=False),
+        sa.Column('description', sa.String, nullable=False),
+        sa.Column('author_id', sa.Integer, sa.ForeignKey('users.id'), nullable=False),
+    )
+
+    op.create_table(
+        'association_discussion_participants',
+        sa.Column('discussion_id', sa.Integer, sa.ForeignKey('discussions.id'), primary_key=True),
+        sa.Column('user_id', sa.Integer, sa.ForeignKey('users.id'), primary_key=True),
+    )
+
+
+def downgrade():
+    op.drop_table('association_discussion_participants')
+    op.drop_table('discussions')

--- a/backend/migrations/versions/7db1c6c31f73_update_discussions_table_to_include_.py
+++ b/backend/migrations/versions/7db1c6c31f73_update_discussions_table_to_include_.py
@@ -1,0 +1,39 @@
+"""Update discussions table to include update time and created time
+
+Revision ID: 7db1c6c31f73
+Revises: 1b1cbd10c22b
+Create Date: 2024-06-14 23:18:18.461813
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '7db1c6c31f73'
+down_revision = '1b1cbd10c22b'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_table('association_discussion_participants')
+    op.create_table(
+        'discussions',
+        sa.Column('id', sa.Integer(), primary_key=True, index=True, autoincrement=True),
+        sa.Column('title', sa.String(), nullable=False),
+        sa.Column('description', sa.String(), nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.func.now(), onupdate=sa.func.now(), nullable=False),
+        sa.Column('user_id', sa.Integer(), sa.ForeignKey('users.id'), nullable=False)
+    )
+
+    op.create_table(
+        'association_discussion_participants',
+        sa.Column('discussion_id', sa.Integer(), sa.ForeignKey('discussions.id'), primary_key=True),
+        sa.Column('user_id', sa.Integer(), sa.ForeignKey('users.id'), primary_key=True)
+    )
+
+def downgrade():
+    op.drop_table('association_discussion_participants')
+    op.drop_table('discussions')

--- a/backend/models/discussion.py
+++ b/backend/models/discussion.py
@@ -1,0 +1,30 @@
+from pydantic import BaseModel
+from typing import List, Optional
+
+from backend.models.user import UserResponse
+
+class DiscussionIdentity(BaseModel):
+    id: int
+
+class Discussion(DiscussionIdentity):
+    title: str
+    description: str
+    participants: List[UserResponse]
+    author: UserResponse
+
+class DiscussionCreate(BaseModel):
+    title: str
+    description: str
+    participants: Optional[List[UserResponse]] = None
+    author: UserResponse
+
+class DiscussionUpdate(BaseModel):
+    title: Optional[str] = None
+    description: Optional[str] = None
+    participants: Optional[List[UserResponse]] = None
+
+class DiscussionResponse(DiscussionIdentity):
+    title: str
+    description: str
+    participants: List[UserResponse]
+    author: UserResponse

--- a/backend/models/discussion.py
+++ b/backend/models/discussion.py
@@ -1,30 +1,24 @@
 from pydantic import BaseModel
-from typing import List, Optional
-
+from datetime import datetime
+from typing import Optional, List
 from backend.models.user import UserResponse
 
 class DiscussionIdentity(BaseModel):
     id: int
 
-class Discussion(DiscussionIdentity):
-    title: str
-    description: str
-    participants: List[UserResponse]
-    author: UserResponse
-
 class DiscussionCreate(BaseModel):
     title: str
     description: str
-    participants: Optional[List[UserResponse]] = None
-    author: UserResponse
+    user_id: int
 
 class DiscussionUpdate(BaseModel):
     title: Optional[str] = None
     description: Optional[str] = None
-    participants: Optional[List[UserResponse]] = None
 
 class DiscussionResponse(DiscussionIdentity):
     title: str
     description: str
+    created_at: datetime
+    updated_at: datetime
+    user_id: int
     participants: List[UserResponse]
-    author: UserResponse


### PR DESCRIPTION
This pull request introduces the Discussions feature to the backend. It includes models, entities, and migration scripts for the Discussions table. The feature allows users to create, update, and retrieve discussion threads associated with user profiles.

## Changes
- **Added**: Pydantic model for Discussion with attributes like `id`, `title`, `description`, `created_at`, `updated_at`, and `user_id`.
- **Added**: SQLAlchemy entity for Discussion with appropriate relationships and schema definitions.
- **Added**: Alembic migration scripts to create the Discussions table in the database.

## Tasks Completed
- Created a Pydantic model for Discussion.
- Defined attributes such as `id`, `title`, `description`, `created_at`, `updated_at`, `user_id`.
- Ensured model validation and serialization.
- Created SQLAlchemy entity for Discussion with relationships.
- Added Alembic migration scripts to set up the Discussions table.

## Issues Closed
- Closes #33 
- Closes #34 
- Closes #35
