### PR TITLE
Dockerfile NPM update

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -40,7 +40,7 @@ RUN mkdir -p /etc/apt/keyrings \
     && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list \
     && apt-get update \
     && apt-get install nodejs -y \
-    && npm install -g npm@latest \
+    && npm install -g npm@10.2.4 \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Angular CLI Globally


### PR DESCRIPTION
Update .devcontainer/Dockerfile to use npm version 10.2.4 instead of @latest for Node 18 compatibility.